### PR TITLE
Add email notifications capability

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,9 +1,0 @@
-# The ID of your GitHub App
-APP_ID=
-WEBHOOK_SECRET=development
-
-# Use `trace` to get verbose logging or `info` to show less
-LOG_LEVEL=debug
-
-# Go to https://smee.io/new set this to the URL that you are redirected to.
-# WEBHOOK_PROXY_URL=

--- a/index.js
+++ b/index.js
@@ -1,10 +1,15 @@
-module.exports = (robot) => {
-  // Your code here
-  robot.log('Yay, the app was loaded!')
+var CreateEmailNotifications = require('./lib/create-email-notifications')
 
-  // For more information on building apps:
-  // https://probot.github.io/docs/
+function probotEmailNotifications (robot) {
+  robot.on('repository.created', async context => {
+    return CreateEmailNotifications.analyze(context.github, context.repo(), context.payload, robot.log)
+  })
 
-  // To get your app running against GitHub, see:
-  // https://probot.github.io/docs/development/
+  robot.on('repository.archived', async context => {
+    return CreateEmailNotifications.analyze(context.github, context.repo(), context.payload, robot.log)
+  })
+
+
 }
+
+module.exports = probotEmailNotifications

--- a/lib/create-email-notifications.js
+++ b/lib/create-email-notifications.js
@@ -1,0 +1,102 @@
+const yaml = require('js-yaml')
+const noOrgConfig = false
+var nodemailer = require('nodemailer');
+
+class CreateEmailNotifications {
+  static analyze (github, repo, payload, logger) {
+    const defaults = require('./defaults')
+    const orgRepo = (process.env.ORG_WIDE_REPO_NAME) ? process.env.ORG_WIDE_REPO_NAME : defaults.ORG_WIDE_REPO_NAME
+    const filename = (process.env.FILE_NAME) ? process.env.FILE_NAME : defaults.FILE_NAME
+    logger.info('Get config from: ' + repo.owner + '/' + orgRepo + '/' + filename)
+
+    return github.repos.getContent({
+      owner: repo.owner,
+      repo: orgRepo,
+      path: filename
+    }).catch(() => ({
+      noOrgConfig
+    }))
+      .then((orgConfig) => {
+        if ('noOrgConfig' in orgConfig) {
+          logger.info('NOTE: config file not found in: ' + orgRepo + '/' + filename + ', using defaults.')
+          return new CreateEmailNotifications(github, repo, payload, logger, '').notify()
+        } else {
+          const content = Buffer.from(orgConfig.data.content, 'base64').toString()
+          return new CreateEmailNotifications(github, repo, payload, logger, content).notify()
+        }
+      })
+  }
+
+  constructor (github, repo, payload, logger, config) {
+    this.github = github
+    this.repo = repo
+    this.payload = payload
+    this.logger = logger
+    this.config = yaml.safeLoad(config)
+  }
+
+  notify (repo) {
+    var configParams = Object.assign({}, require('./defaults'), this.config || {})
+
+    console.log('Action:', this.payload.action)
+    if (this.payload.action === 'created') {
+      if (!configParams.enableCreateNotification) {
+          this.logger.info('Repo: ' + this.repo.repo + ' was created but enableCreateNotification is set to false')
+          return
+      }
+
+      var transporter = nodemailer.createTransport(configParams.transportConfig);
+      var mailText = configParams.createEmailBody + this.payload.repository.html_url // https://github.com/' + repo.owner + '/' + repo.repo
+      var mailOptions = {
+        from: configParams.transportConfig.auth.user,
+        to: configParams.createRecipientList,
+        subject: configParams.createEmailSubject,
+        text: mailText
+      };
+
+      transporter.sendMail(mailOptions, function(error, info){
+        if (error) {
+          this.logger.error(error);
+        } else {
+          this.logger.info('Email sent: ' + info.response);
+        }
+      });
+      return
+    }
+
+    if (this.payload.action === 'archived') {
+      if (!configParams.enableArchiveNotification) {
+          this.logger.info('Repo: ' + this.repo.repo + ' was archived but enableArchiveNotification is set to false')
+          return
+      }
+
+      var transporter = nodemailer.createTransport(configParams.transportConfig);
+      var mailText = configParams.archiveEmailBody + this.payload.repository.html_url // https://github.com/' + repo.owner + '/' + repo.repo
+      var mailOptions = {
+        from: configParams.transportConfig.auth.user,
+        to: configParams.archiveRecipientList,
+        subject: configParams.archiveEmailSubject,
+        text: mailText
+      };
+
+      transporter.sendMail(mailOptions, function(error, info){
+        if (error) {
+          this.logger.error(error);
+        } else {
+          this.logger.info('Email sent: ' + info.response);
+        }
+      });
+      return
+    }
+
+  }
+
+  isPublicizedAndConvertDisabled (enableArchiveNotification) {
+    if (this.payload.action === 'archived' && !enableArchiveNotification) {
+      this.logger.info('Repo: ' + this.repo.repo + ' was archived but enableArchiveNotification is set to false')
+      return true
+    }
+    return false
+  }
+}
+module.exports = CreateEmailNotifications

--- a/lib/create-email-notifications.js
+++ b/lib/create-email-notifications.js
@@ -3,6 +3,9 @@ const noOrgConfig = false
 var nodemailer = require('nodemailer');
 
 class CreateEmailNotifications {
+
+  // Analyze checks for the existence of an organization-wide repository created for the purpose of configurng Probot apps. By default, the path of this configuration file is https://github.com/[ORG_NAME]/org-settings/.github/create-email-notifications.yml. Both the repository name and file path can be configured in defaults.js. If no configuration file exists at the specified location, default values are used as configured in defaults.js
+
   static analyze (github, repo, payload, logger) {
     const defaults = require('./defaults')
     const orgRepo = (process.env.ORG_WIDE_REPO_NAME) ? process.env.ORG_WIDE_REPO_NAME : defaults.ORG_WIDE_REPO_NAME
@@ -35,18 +38,23 @@ class CreateEmailNotifications {
     this.config = yaml.safeLoad(config)
   }
 
+
   notify (repo) {
     var configParams = Object.assign({}, require('./defaults'), this.config || {})
 
-    console.log('Action:', this.payload.action)
+    // This implementation block creates a notification email if a repository has been created.
     if (this.payload.action === 'created') {
+      // If `enableCreateNotification = false in the configuration, no email will be sent.`
       if (!configParams.enableCreateNotification) {
           this.logger.info('Repo: ' + this.repo.repo + ' was created but enableCreateNotification is set to false')
           return
       }
 
-      var transporter = nodemailer.createTransport(configParams.transportConfig);
-      var mailText = configParams.createEmailBody + this.payload.repository.html_url // https://github.com/' + repo.owner + '/' + repo.repo
+      // Uses Nodemailer (https://nodemailer.com/about/) to send emails. The default transport configuration is set to use Gmail, but standard SMTP configuration options are also available (see https://nodemailer.com/smtp/). The transport configuration object can be created in defaults.js, or in the configuration yml file.
+      const transporter = nodemailer.createTransport(configParams.transportConfig);
+
+      // Generates the body of the email to be sent as well as the sender, recipent, and subject of the email from the configuration file.
+      const mailText = configParams.createEmailBody + this.payload.repository.html_url
       var mailOptions = {
         from: configParams.transportConfig.auth.user,
         to: configParams.createRecipientList,
@@ -64,6 +72,7 @@ class CreateEmailNotifications {
       return
     }
 
+    // This implementation block creates a notification email if a repository has been archived.
     if (this.payload.action === 'archived') {
       if (!configParams.enableArchiveNotification) {
           this.logger.info('Repo: ' + this.repo.repo + ' was archived but enableArchiveNotification is set to false')
@@ -71,7 +80,7 @@ class CreateEmailNotifications {
       }
 
       var transporter = nodemailer.createTransport(configParams.transportConfig);
-      var mailText = configParams.archiveEmailBody + this.payload.repository.html_url // https://github.com/' + repo.owner + '/' + repo.repo
+      var mailText = configParams.archiveEmailBody + this.payload.repository.html_url
       var mailOptions = {
         from: configParams.transportConfig.auth.user,
         to: configParams.archiveRecipientList,
@@ -88,15 +97,6 @@ class CreateEmailNotifications {
       });
       return
     }
-
-  }
-
-  isPublicizedAndConvertDisabled (enableArchiveNotification) {
-    if (this.payload.action === 'archived' && !enableArchiveNotification) {
-      this.logger.info('Repo: ' + this.repo.repo + ' was archived but enableArchiveNotification is set to false')
-      return true
-    }
-    return false
   }
 }
 module.exports = CreateEmailNotifications

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -1,0 +1,18 @@
+module.exports = {
+  enableArchiveNotification: true,
+  enableCreateNotification: true,
+  archiveEmailSubject: 'GitHub Repository Archived',
+  archiveEmailBody: 'The following repository has been archived in GitHub: ',  createEmailSubject: 'GitHub Repository Created',
+  createEmailBody: 'A new repository has been created in GitHub at the following location: ',
+  archiveRecipientList: 'migarjo@github.com;gracepark@github.com',
+  createRecipientList: 'migarjo@github.com',
+  transportConfig: {
+    service: 'gmail',
+    auth: {
+      user: process.env.GMAIL_ADDRESS,
+      pass: process.env.GMAIL_PASSWORD
+    }
+  },
+  FILE_NAME: '.github/create-email-notifications.yml',
+  ORG_WIDE_REPO_NAME: 'org-settings'
+}

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "test:watch": "jest --watch --notify --notifyMode=change --coverage"
   },
   "dependencies": {
+    "nodemailer": "^4.6.4",
     "probot": "^6.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This pull request builds upon the bootstrapped Probot app as generated by:

`npx create-probot-app my-first-app`

This implements an email notification system using [Nodemailer](https://nodemailer.com/about/), and listens for repository.created and repository.archived webhooks from GitHub. The creation and archive events each generate a different email body, which can be configured in a specified repository in the organization in which this app is installed, or configured by default in `lib/defaults.js`.